### PR TITLE
Small changes to make app work out of the box

### DIFF
--- a/generators/package/templates/README.md
+++ b/generators/package/templates/README.md
@@ -46,7 +46,7 @@ Developing static assets? Move into the pluggable app's staticapp directory and 
 
   ```
   $ cd <%= app %>/staticapp
-  $ gulp
+  $ npm start
   ```
 
 Want to not worry about it? Use the shortcut make command.

--- a/generators/package/templates/app/staticapp/package.json
+++ b/generators/package/templates/app/staticapp/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.1",
   "description": "Static assets for <%= app %>, a Django app.",
   "scripts": {
-    "start": "webpack-dev-server --config webpack.config.dev.js",
-    "build": "webpack --mode=production --config webpack.config.prod.js"
+    "start": "webpack-dev-server --config webpack-dev.config.js",
+    "build": "webpack --mode=production --config webpack-prod.config.js"
   },
   "dependencies": {
     "classnames": "*",

--- a/generators/package/templates/app/templates/app/home.html
+++ b/generators/package/templates/app/templates/app/home.html
@@ -6,7 +6,7 @@
   </head>
   <body>
     <img src="https://rawgithub.com/The-Politico/src/master/images/logo/badge.png" />
-    <h1 style="margin-top:0px;">Hello, mothership!</h1>
+    <h1 style="margin-top:0px;">Hello, mother!</h1>
 
     <iframe width="560" height="315" src="https://www.youtube.com/embed/jesc3yvZSws?rel=0&amp;showinfo=0&amp;autoplay=1" frameborder="0"  allow="autoplay" allowfullscreen></iframe>
 

--- a/generators/package/templates/app/templates/app/home.html
+++ b/generators/package/templates/app/templates/app/home.html
@@ -8,7 +8,7 @@
     <img src="https://rawgithub.com/The-Politico/src/master/images/logo/badge.png" />
     <h1 style="margin-top:0px;">Hello, mothership!</h1>
 
-    <iframe width="560" height="315" src="https://www.youtube.com/embed/2u-n__lHhWU?rel=0&amp;showinfo=0&amp;autoplay=1" frameborder="0"  allow="autoplay" allowfullscreen></iframe>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/jesc3yvZSws?rel=0&amp;showinfo=0&amp;autoplay=1" frameborder="0"  allow="autoplay" allowfullscreen></iframe>
 
     <!-- Use me to authenticate basic AJAX requests -->
     <input  type="hidden" value="{{secret}}" />

--- a/generators/package/templates/app/templates/app/home.html
+++ b/generators/package/templates/app/templates/app/home.html
@@ -6,9 +6,9 @@
   </head>
   <body>
     <img src="https://rawgithub.com/The-Politico/src/master/images/logo/badge.png" />
-    <h1 style="margin-top:0px;">Hello, mother!</h1>
+    <h1 style="margin-top:0px;">Hello, mothership!</h1>
 
-    <iframe width="560" height="315" src="https://www.youtube.com/embed/V7uEb_XrK1U?rel=0&amp;showinfo=0&amp;autoplay=1" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen></iframe>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/2u-n__lHhWU?rel=0&amp;showinfo=0&amp;autoplay=1" frameborder="0"  allow="autoplay" allowfullscreen></iframe>
 
     <!-- Use me to authenticate basic AJAX requests -->
     <input  type="hidden" value="{{secret}}" />

--- a/generators/packaging/templates/Makefile
+++ b/generators/packaging/templates/Makefile
@@ -5,8 +5,15 @@ ship:
 	python setup.py sdist bdist_wheel
 	twine upload dist/* --skip-existing
 
+dev-backend:
+	cd example && pipenv run python manage.py runserver
+
+dev-frontend:
+	sleep 3  # Stall while backend starts
+	cd <%= app %>/staticapp && npm start
+
 dev:
-	gulp --cwd <%= app %>/staticapp/
+	make -j 2 dev-backend dev-frontend
 
 database:
 	dropdb <%= app %> --if-exists


### PR DESCRIPTION
**Note:** I've been experimenting with some of your tools since NICAR and thought it would be helpful to fix small things as I find them. Thanks so much for making these tools open source!

Make a few minor changes to make the app work out of the box according to the README and clear up some small inconsistencies. The changes fall into the following three categories:

1. Make the filenames of the webpack config files referenced in `staticapp/package.json` match the filenames of the generated files. The generator was creating, e.g.,  `webpack-dev.config.js` but the the `package.json` start command was expecting `webpack.config.dev.js`. I chose the former convention, but you may want to go the other way, depending on your preference (in which case you would make a few changes around line 60 of `generators/package/index.js`).

2. Finish removing gulp from the README instructions on how to start `staticapp` in dev and from the `make dev` target of the Makefile. The `dev` target was trying to run gulp, but it looks like you intentionally got rid of gulp, so I swapped that for a slightly more intricate Makefile for which `make dev` will run both the example Django server and `staticapp`.

3. I noticed that your video in the home page template was taken down, so I went ahead and fixed that for you :)

I love the work you're all doing and I hope my contributions are more of a help than a nuisance.